### PR TITLE
Remove Framer Motion as a dependency

### DIFF
--- a/example/src/components/Intro.tsx
+++ b/example/src/components/Intro.tsx
@@ -4,7 +4,7 @@ import { useKmenu } from 'kmenu'
 
 const Intro: FC = () => {
   // @ts-ignore
-  const [input, setInput, open, setOpen, toggle] = useKmenu()
+  const { toggle } = useKmenu()
 
   return (
     <div>


### PR DESCRIPTION
Framer Motion makes up the bulk of this package dependency. Nobody wants to add a 75kB package if they don't have to. 
This update should reduce the minified size to  ~16.2mB.