### PR TITLE
Added missing dependencies for `useCallback` and `useEffect` functions inside `useShortcut` hook

### DIFF
--- a/src/hooks/useShortcut.ts
+++ b/src/hooks/useShortcut.ts
@@ -41,11 +41,11 @@ export const useShortcut = ({
         handler?.()
       }
     }
-  }, [])
+  }, [handler, setKeyPressed])
 
   const upHandler = useCallback((event: KeyboardEvent) => {
     if (event.key === targetKey) setKeyPressed(false)
-  }, [])
+  }, [setKeyPressed])
 
   useEffect(() => {
     window.addEventListener('keydown', downHandler)
@@ -55,7 +55,7 @@ export const useShortcut = ({
       window.removeEventListener('keydown', downHandler)
       window.removeEventListener('keyup', upHandler)
     }
-  }, [])
+  }, [upHandler, downHandler])
 
   return keyPressed
 }


### PR DESCRIPTION
### Why?

I was using the useShortcut hook to reset a `@tiptap/react` editor in this manner.

```tsx
  const editor = useEditor({
    extensions: [
      StarterKit.configure({
        heading: { levels: [1, 2] },
      }),
    ],
    onUpdate: ({ editor }) => {
      editStoreData('editorJson', editor.getJSON().content);
    },
    onCreate: ({ editor }) => {
      editStoreData('editorJson', editor.getJSON().content);
    },
    editorProps: {
      attributes: {
        class:
          'prose prose-sm sm:prose lg:prose-lg xl:prose-2xl focus:outline-none',
      },
    },
    content: { type: 'doc', content: editorJson },
  });

  useShortcut({
    modifier: 'meta',
    targetKey: 'k',
    handler: () => {
      if (!editor) return toast.error('unable to reset: editor is undefined');
      editor.commands.setContent(constants.DEFAULT_CONTENT);
    },
  });
```

And I kept getting the toast error whenever the shortcut was matched, because `editor` was undefined. However, I was able to access `editor` through another function.

This meant that the `editor` value was undefined when initialized, but changed after initialization. But, it was still undefined for the useShortcut hook, which meant that it was not being updated. 

So I fixed the missing dependencies for the useShortcut hook.

I'm sure missing dependencies exist across the project, but I've just fixed the part I was using 😅