### PR TITLE
feat: add property to receive Link component in command

### DIFF
--- a/src/Command.tsx
+++ b/src/Command.tsx
@@ -33,13 +33,11 @@ const Command: FC<{
     }
   }, [isSelected, enter])
 
-  const Link = command.Anchor
-
   return (
     <div role='option' aria-selected={isSelected}>
       <span ref={topRef} aria-hidden='true' />
-      {Link ? (
-        <Link
+      {command.anchor ? (
+        <command.anchor
           className='command'
           onMouseMove={onMouseEnter}
           style={{
@@ -92,7 +90,7 @@ const Command: FC<{
               ))}
             </div>
           )}
-        </Link>
+        </command.anchor>
       ) : (
         <a
           className='command'
@@ -149,7 +147,6 @@ const Command: FC<{
           )}
         </a>
       )}
-
       <span ref={bottomRef} className='scroll_ref' aria-hidden='true' />
     </div>
   )

--- a/src/Command.tsx
+++ b/src/Command.tsx
@@ -33,63 +33,123 @@ const Command: FC<{
     }
   }, [isSelected, enter])
 
+  const Link = command.Anchor
+
   return (
     <div role='option' aria-selected={isSelected}>
       <span ref={topRef} aria-hidden='true' />
-      <a
-        className='command'
-        onMouseMove={onMouseEnter}
-        style={{
-          color: isSelected
-            ? config?.commandActive || '#343434'
-            : config?.commandInactive || '#828282'
-        }}
-        onClick={() => {
-          if (!command.closeOnComplete) setOpen(0)
-          run(command)
-        }}
-        href={command.href || '#'}
-        target={command.newTab ? '_blank' : '_self'}
-        rel='noreferrer'
-      >
-        {isSelected && (
-          <motion.div
-            layoutId='box'
-            className='selected'
-            initial={false}
-            aria-hidden='true'
-            transition={{ type: 'spring', stiffness: 1000, damping: 80 }}
-            style={{ background: config?.barBackground || '#82828220' }}
-          />
-        )}
-        <div className='info_wrapper'>
-          {command.icon && command.icon}
-          <p className='command_text'>{command.text}</p>
-        </div>
-        {command.shortcuts && (
-          <div className='shortcuts'>
-            {command.shortcuts.modifier && (
-              <kbd
-                style={{
-                  backgroundColor: config?.shortcutBackground || '#82828220'
-                }}
-              >
-                {command.shortcuts.modifier}
-              </kbd>
-            )}
-            {command.shortcuts.keys.map((key, index) => (
-              <kbd
-                key={index}
-                style={{
-                  backgroundColor: config?.shortcutBackground || '#82828220'
-                }}
-              >
-                {key}
-              </kbd>
-            ))}
+      {Link ? (
+        <Link
+          className='command'
+          onMouseMove={onMouseEnter}
+          style={{
+            color: isSelected
+              ? config?.commandActive || '#343434'
+              : config?.commandInactive || '#828282'
+          }}
+          onClick={() => {
+            if (!command.closeOnComplete) setOpen(0)
+            run(command)
+          }}
+          href={command.href || '#'}
+          target={command.newTab ? '_blank' : '_self'}
+          rel='noreferrer'
+        >
+          {isSelected && (
+            <motion.div
+              layoutId='box'
+              className='selected'
+              initial={false}
+              aria-hidden='true'
+              transition={{ type: 'spring', stiffness: 1000, damping: 80 }}
+              style={{ background: config?.barBackground || '#82828220' }}
+            />
+          )}
+          <div className='info_wrapper'>
+            {command.icon && command.icon}
+            <p className='command_text'>{command.text}</p>
           </div>
-        )}
-      </a>
+          {command.shortcuts && (
+            <div className='shortcuts'>
+              {command.shortcuts.modifier && (
+                <kbd
+                  style={{
+                    backgroundColor: config?.shortcutBackground || '#82828220'
+                  }}
+                >
+                  {command.shortcuts.modifier}
+                </kbd>
+              )}
+              {command.shortcuts.keys.map((key, index) => (
+                <kbd
+                  key={index}
+                  style={{
+                    backgroundColor: config?.shortcutBackground || '#82828220'
+                  }}
+                >
+                  {key}
+                </kbd>
+              ))}
+            </div>
+          )}
+        </Link>
+      ) : (
+        <a
+          className='command'
+          onMouseMove={onMouseEnter}
+          style={{
+            color: isSelected
+              ? config?.commandActive || '#343434'
+              : config?.commandInactive || '#828282'
+          }}
+          onClick={() => {
+            if (!command.closeOnComplete) setOpen(0)
+            run(command)
+          }}
+          href={command.href || '#'}
+          target={command.newTab ? '_blank' : '_self'}
+          rel='noreferrer'
+        >
+          {isSelected && (
+            <motion.div
+              layoutId='box'
+              className='selected'
+              initial={false}
+              aria-hidden='true'
+              transition={{ type: 'spring', stiffness: 1000, damping: 80 }}
+              style={{ background: config?.barBackground || '#82828220' }}
+            />
+          )}
+          <div className='info_wrapper'>
+            {command.icon && command.icon}
+            <p className='command_text'>{command.text}</p>
+          </div>
+          {command.shortcuts && (
+            <div className='shortcuts'>
+              {command.shortcuts.modifier && (
+                <kbd
+                  style={{
+                    backgroundColor: config?.shortcutBackground || '#82828220'
+                  }}
+                >
+                  {command.shortcuts.modifier}
+                </kbd>
+              )}
+              {command.shortcuts.keys.map((key, index) => (
+                <kbd
+                  key={index}
+                  style={{
+                    backgroundColor: config?.shortcutBackground || '#82828220'
+                  }}
+                >
+                  {key}
+                </kbd>
+              ))}
+            </div>
+          )}
+        </a>
+      )}
+
       <span ref={bottomRef} className='scroll_ref' aria-hidden='true' />
     </div>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { Dispatch, ReactElement, RefObject, SetStateAction } from 'react'
+import {
+  AnchorHTMLAttributes,
+  Dispatch,
+  FunctionComponent,
+  ReactElement,
+  RefObject,
+  SetStateAction
+} from 'react'
 
 export type MenuContext = {
   /**
@@ -138,6 +145,7 @@ export type SortedCommands = {
   category: string
   commands: GlobalCommand[]
 }
+type navLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export type CategoryCommand = {
   /**
@@ -173,6 +181,7 @@ export type CategoryCommand = {
    * Whether or not to close this menu when the functino is called
    */
   closeOnComplete?: boolean
+  Anchor?: FunctionComponent<navLinkProps>
 }
 
 export type Shortcut = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import {
   AnchorHTMLAttributes,
   Dispatch,
-  FunctionComponent,
+  FC,
   ReactElement,
   RefObject,
   SetStateAction
@@ -145,7 +145,8 @@ export type SortedCommands = {
   category: string
   commands: GlobalCommand[]
 }
-type navLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
+
+type NavLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export type CategoryCommand = {
   /**
@@ -178,10 +179,13 @@ export type CategoryCommand = {
    */
   shortcuts?: Shortcut
   /**
-   * Whether or not to close this menu when the functino is called
+   * Whether or not to close this menu when the function is called
    */
   closeOnComplete?: boolean
-  Anchor?: FunctionComponent<navLinkProps>
+  /**
+   * Allow for custom HTML to be passed as the anchor property
+  */
+  anchor?: FC<NavLinkProps>
 }
 
 export type Shortcut = {


### PR DESCRIPTION
Hi there,

I've added a new feature to the menu command library for React. Previously, it only supported HTML links for navigation, but I've added the ability to pass a Next.js Link component as a property.

This change should make it easier for users of the library who are working with Next.js to integrate the menu command into their projects.

Please let me know if there are any changes or improvements that need to be made.

exemple to use with `Link`  next component : 
```tsx
{
      category: 'Links',
      commands: [
        {
          icon: <FiGithub />,
          text: 'Source Code',
          keywords: 'GitHub',
          shortcuts: { keys: ['g', 'h'] },
          href: 'https://github.com/harshhhdev/kmenu',
          Anchor: ({ children, ...props }) => (
            <Link {...props}>
              {children}
            </Link>
            
          ),
          newTab: true
        }....
```

Thank you,
[Yazalde Filimone](https://github.com/yazaldefilimonepinto)